### PR TITLE
fixed unify(x,0) and unify(0,x) failed

### DIFF
--- a/Prover/docs/proofdebug20190421.txt
+++ b/Prover/docs/proofdebug20190421.txt
@@ -100,7 +100,15 @@ Valid
  
  こんなかんじ
  
- 
+
+20190422
+naiveでみると、R7と c13 のresolutionで
+p1_C23R7に0.95がはいるはずなのに、nativeでははいっているらしいが
+cheapでははいっていない
+
+20190423
+となると、unifyするliteralの順番かも
+executable以外を優先してresolution適用が必要なのか??
 
 
 

--- a/Prover/dvcreso.jl
+++ b/Prover/dvcreso.jl
@@ -107,7 +107,7 @@ end
 ## evaluation 
 
 function leval(lit)
-@show :leval, lit
+#@show :leval, lit
   try
     val=eval(lit.args[2])
     if val==true
@@ -124,15 +124,13 @@ function leval(lit)
 end
 
 function evaluate_literals(lids, lits)
-@show :evaluate_literals,lits
+#@show :evaluate_literals,lits
  rlits=[]
  rlids=[]
  for lix in 1:length(lids) 
    lid=lids[lix]
    lit=lits[lix]
-@show lid,lit
    val = leval(lit)
-@show val
    if val == true; return true,true end
    if val == false; continue end
    push!(rlits,lit)
@@ -175,9 +173,7 @@ function dvc_resolution(l1,l2,core)
    nbody = literalsof(rem, core)
    nbody1 = apply(ovars, nbody, sigmai)
    if evalon
-@show vars
      rb = evaluate_literals(nrem, nbody1) 
-@show rb
      if rb[1] == true
        println("Valid")
        return :FAIL 

--- a/Prover/naiveunify.jl
+++ b/Prover/naiveunify.jl
@@ -38,7 +38,7 @@ function direction(vars::Vlist, t1::Any, t2::Any)
     isa(t1, Expr) && loopcheck(t2, t1)
     return (t2, t1)
   end
-@show typeof(t1), typeof(t2)
+#@show typeof(t1), typeof(t2)
   throw(ICMP(t1,t2,:directionaa))
 end
 

--- a/Prover/test_naiveunify.jl
+++ b/Prover/test_naiveunify.jl
@@ -36,6 +36,13 @@ end
  @test unify([:x],:(P(x)), :(P(y))) == [:y]
  @test unify([:y],:(P(x)), :(P(y))) == [:x]
 
+ @testset "with number" begin
+  @test unify([], :(f(2)), :(f(2))) == []
+  @test unify([:x], :(f(x)), :(f(2))) == [2]
+  @test unify([:x], :(f(3)), :(f(x))) == [3]
+  @test unify([:x,:y], :(f(3,y)), :(f(x,23))) == [3,23]
+ end
+
 # in this case, x and y are constants
  @test_throws ICMP unify([:z],:(P(x)), :(P(y)))
 

--- a/Prover/testunify.jl
+++ b/Prover/testunify.jl
@@ -88,6 +88,12 @@ end
  @test unify([:x],:(P(x)), :(P(y))) == [:y]
  @test unify([:y],:(P(x)), :(P(y))) == [:x]
 
+ @testset  "with number" begin
+  @test unify([], :(f(2)), :(f(2))) == []
+  @test unify([:x], :(f(x)), :(f(2))) == [2]
+  @test unify([:x], :(f(3)), :(f(x))) == [3]
+  @test unify([:x,:y], :(f(3,y)), :(f(x,23))) == [3,23]
+ end
 # in this case, x and y are constants
  @test_throws ICMP unify([:z],:(P(x)), :(P(y)))
 

--- a/Prover/unify.jl
+++ b/Prover/unify.jl
@@ -14,12 +14,6 @@ function unify0(vars::Vlist, t1::Number, t2::Number)
  throw(ICMP(t1,t2,:unify0nn))
 end
 
-function unify0(vars::Vlist, t1::Number, t2::Symbol)
- if isvar(t1,vars); return (t1,t2) end
-# if isvar(t2,vars); return (t2,t1) end
- throw(ICMP(t1,t2,:unify0ns))
-end
-
 function unify0(vars::Vlist, t1::Number, t2::Expr)
  throw(ICMP(t1,t2,:unify0ne))
 end
@@ -28,13 +22,20 @@ function unify0(vars::Vlist, t1::Expr, t2::Number)
  throw(ICMP(t1,t2,:unify0en))
 end
 
-function unify0(vars::Vlist, t1::Symbol, t2::Number)
-# if isvar(t1,vars); return (t1,t2) end
+function unify0(vars::Vlist, t1::Number, t2::Symbol)
+##@show :unify0ns,vars,t1,t2
  if isvar(t2,vars); return (t2,t1) end
+ throw(ICMP(t1,t2,:unify0ns))
+end
+
+function unify0(vars::Vlist, t1::Symbol, t2::Number)
+#@show :unify0sn,vars,t1,t2
+ if isvar(t1,vars); return (t1,t2) end
  throw(ICMP(t1,t2,:unify0sn))
 end
 
 function unify0(vars::Vlist, t1::Symbol, t2::Symbol)
+#@show :unify0ss,t1,t2
  if t1==t2; return () end
  if isvar(t1,vars) && isvar(t2,vars)
    if isinvar(t1); return (t2,t1) end
@@ -47,16 +48,19 @@ end
 
 
 function unify0(vars::Vlist, t1::Symbol, t2::Expr)
+#@show :unify0se,t1,t2
  isvar(t1,vars) && !loopcheck(t1,t2) && return (t1,t2) 
  if t1!=t2; throw(ICMP(t1,t2,:unify0se)) end
 end
 
 function unify0(vars::Vlist, t1::Expr, t2::Symbol)
+#@show :unify0es,t1,t2
  isvar(t2,vars)&&!loopcheck(t2,t1)&&return(t2,t1)
  if t1!=t2; throw(ICMP(t1,t2,:unify0es)) end
 end
 
 function unify0(vars::Vlist, t1::Expr, t2::Expr)
+#@show :unify0ee,t1,t2
  if t1==t2; return () end
  for i in 1:length(t1.args)
   if t1.args[i]==t2.args[i]; continue end
@@ -68,23 +72,6 @@ end
 
 ### unify do unification
 # t1,t2 are literal(without sign, without or/and.
-
-#function unify1(vars::Vlist, t1::Symbol, t2::Symbol, subst::Tlist)
-##  if t1!=t2; throw(ICMP(t1,t2,:unify1)) end
-#  σb=vars
-#  while(true)
-#   σa0=unify0(vars,t1,t2)
-#   if σa0==(); break end
-#   σa = maketlist(vars, σa0[1], σa0[2]) 
-##@show σa
-#   σi::Tlist = merge(vars, σb, σa)
-##@show σi
-#   t1 = apply(t1,σi,σb)
-#   t2 = apply(t2,σi,σb)
-#   σb=σa
-#  end
-# σb
-#end
 
 function unify1(vars::Vlist, t1::Number, t2::Number, subst::Tlist)
 #@show :unify1vnn,t1,t2,subst
@@ -213,7 +200,7 @@ end
 unify1 has a var subst for internal use
 """
 function unify1(vars::Vlist, t1::Expr, t2::Expr, subst::Tlist)
-#@show :unify1vee,t1,t2,subst
+#@show :unifyvee,t1,t2,subst
  if t1==t2; 
   return subst
  end
@@ -224,6 +211,7 @@ function unify1(vars::Vlist, t1::Expr, t2::Expr, subst::Tlist)
 
  if length(t1.args) != length(t2.args); return vars end
  while true  
+#@show :unify0,vars,t1,t2
   pp = unify0(vars, t1, t2)
   if isempty(pp); break end
   subst = putasubst(vars, pp[1], pp[2], subst)


### PR DESCRIPTION
unify0(vars, symbol, number) and unify0(vars, number, symbol)
are crazied.

	modified:   docs/proofdebug20190421.txt
	modified:   dvcreso.jl
	modified:   naiveunify.jl
	modified:   test_naiveunify.jl
	modified:   testunify.jl
	modified:   unify.jl