### PR TITLE
changed the cano format in CNF

### DIFF
--- a/Prover/utils.jl
+++ b/Prover/utils.jl
@@ -28,7 +28,7 @@ end
 function adjustcano(cano)
  vcano = Dict{Symbol, Any}()
  for can in cano
-  vcano[can.args[1]] = (can.args[2:end], can)
+  vcano[can.args[2].args[1].args[1].args[1]] = (can.args[1].args, can.args[2].args[1].args[1])
  end
  vcano
 end

--- a/Prover/vdata/vl003.cnf
+++ b/Prover/vdata/vl003.cnf
@@ -22,7 +22,7 @@
 [].[+Pay(Chess,99,99999999)]
 
 
-&Pers(NAME, AGE)
-&Adduser(NAME!, ID)
-&Pay(NAME!,ID!,CARD)
+&[NAME,AGE].[Pers(NAME, AGE)]
+&[NAME!,ID].[Adduser(NAME!, ID)]
+&[NAME!,ID!,CARD].[Pay(NAME!,ID!,CARD)]
 

--- a/Prover/vdata/vl004.cnf
+++ b/Prover/vdata/vl004.cnf
@@ -12,7 +12,7 @@
  [].[+Pay(1,5555)]
 
  Cano
-&P(NAME, ID)
-&Q(NAME, AGE)
-&Pay(ID,CARD)
+&[NAME,ID].[P(NAME, ID)]
+&[NAME,AGE].[Q(NAME, AGE)]
+&[ID,CARD].[Pay(ID,CARD)]
 

--- a/Prover/vdata/vl005.cnf
+++ b/Prover/vdata/vl005.cnf
@@ -15,7 +15,7 @@
  [].[+Pay(2,0)]
 
 
-&P(NAME, ID)
-&Q(NAME, AGE)
-&Pay(ID,CARD)
+&[NAME,ID].[P(NAME, ID)]
+&[NAME,AGE].[Q(NAME, AGE)]
+&[ID,CARD].[Pay(ID,CARD)]
 

--- a/Prover/vdata/vl006.cnf
+++ b/Prover/vdata/vl006.cnf
@@ -17,7 +17,7 @@
  [].[+Pay(2,0)]
 
 
-&P(NAME, ID)
-&Q(NAME, AGE)
-&Pay(ID,CARD)
+&[NAME,ID].[P(NAME, ID)]
+&[NAME,AGE].[Q(NAME, AGE)]
+&[ID,CARD].[Pay(ID,CARD)]
 

--- a/Prover/vdata/vl007.cnf
+++ b/Prover/vdata/vl007.cnf
@@ -19,7 +19,7 @@
 [].[+Pay(2,0)]
 
 
-&P(NAME, ID)
-&Q(NAME, AGE)
-&Pay(ID,CARD)
+&[NAME,ID].[P(NAME, ID)]
+&[NAME,AGE].[Q(NAME, AGE)]
+&[ID,CARD].[Pay(ID,CARD)]
 

--- a/Prover/vlogic/testviewreso.jl
+++ b/Prover/vlogic/testviewreso.jl
@@ -17,9 +17,9 @@ ggg(x) = x^2
 end
 
 cano="""
-&P(NAME, ID)
-&Q(NAME, AGE)
-&Pay(ID,CARD)
+&[NAME,ID].[P(NAME, ID)]
+&[NAME,AGE].[Q(NAME, AGE)]
+&[ID,CARD].[Pay(ID,CARD)]
 """
 cc = readcore(IOBuffer(cano))
 
@@ -40,9 +40,9 @@ cnf="""
 [x,y].[+R(x,y)] #L1
 [z].[-Q(a,b,z)] #L3
 [x,y,z].[-Q(x,y,z)] #L4
-&P(NAME, AGE)
-&R(DOME!,ZOOM)
-&Q(W1!,W2!,W3)
+&[NAME, AGE].[P(NAME, AGE)]
+&[DOME!,ZOOM].[R(DOME!,ZOOM)]
+&[W1!,W2!,W3].[Q(W1!,W2!,W3)]
 """
 c1=readcore(IOBuffer(cnf))
 
@@ -68,9 +68,9 @@ cnf2="""
 [x,y,z].[+R(x,y),-Q(x,y,z),-Q(a,z,z)] #C4=L10,L11,L12
 [x].[-S(x),-P(x,a)]                   #C5=L13,L14
 [x,z].[-S(x),-Q(x,a,z),-P(x,y)]       #C6=L5,L6,L7
-&P(NAME, AGE)
-&R(DOME!,ZOOM)
-&Q(W1!,W2!,W3)
+&[NAME, AGE].[P(NAME, AGE)]
+&[DOME!,ZOOM].[R(DOME!,ZOOM)]
+&[W1!,W2!,W3].[Q(W1!,W2!,W3)]
 """
 c2=readcore(IOBuffer(cnf2))
 
@@ -83,9 +83,9 @@ cnf3="""
 [x,y,z].[+eee(3,3),-F(x,y,z),-R(a,z,z)] #C4
 [x].[-S(x),-eee(2,2)]                   #C5
 [x,z].[-S(x),-Q(x,a,z),-P(x,y)]         #C6
-&P(NAME, AGE)
-&R(DOME!,ZOOM)
-&Q(W1!,W2!,W3)
+&[NAME, AGE].[P(NAME, AGE)]
+&[DOME!,ZOOM].[R(DOME!,ZOOM)]
+&[W1!,W2!,W3].[Q(W1!,W2!,W3)]
 """
 c3=readcore(IOBuffer(cnf3))
 


### PR DESCRIPTION
now it is

&[X,Y].[P(X,Y)]

the order of vars of cano literal should be same as other P literal's args
therefore vars should be.

	modified:   ../utils.jl
	modified:   ../vdata/vl003.cnf
	modified:   ../vdata/vl004.cnf
	modified:   ../vdata/vl005.cnf
	modified:   ../vdata/vl006.cnf
	modified:   ../vdata/vl007.cnf
	modified:   testviewreso.jl