### PR TITLE
fixed: test_kplogic.jl, test_naivelogic.jl failed.

### DIFF
--- a/Prover/README
+++ b/Prover/README
@@ -129,13 +129,14 @@ experimantal codes
  viewprover is a web server. 
 
  1 after include("load_viewprover.jl") in Prover directry.
- 2 open http://localhost:8000/go?op=start, It requires the cnf file path.
+ 2 open http://localhost:8000/go?op=start, It asks a cnf file path.
 
 ## files
- vlogic/viewreso.jl
- vlogic/viewlogic.jl
- vlogic/vhtmls.jl
+ vlogic/viewreso.jl  functions don't directly concern web flow
+ vlogic/viewlogic.jl functions concern web flow
+ vlogic/vhtmls.jl    html maker
 
 ## data
- vdata/vev002.cnf
+ vdata/vev002.cnf has all goals for important test 
+
 

--- a/Prover/docs/devlog
+++ b/Prover/docs/devlog
@@ -4,6 +4,61 @@ QEDは☕️でしめす。
 重要なことは🎂でしめす。「こう」
 何かの影響を🕸でしめす。「す」
 
+20190818日
+1. test_*.jlを確認する
+ 1) 🕷 test_kplogic.jl でCOREの再定義がおきた。
+　　　　COREの定義にいろいろ追加していたからだろう。
+    ☕️ kpcore.jlのCOREの定義が古いようだったので、コメントアウトしてみた
+       でtest_kplogicは正常にとおった
+
+ 2) test_naivelogic.jlは
+        kpcore.jlの意味は忘れたが、なぜこのような定義が必要なのか?
+
+###
+(vars, t1, t2, σ) = (Any[], :(P()), :(Q()), Any[])
+(vars, t1, t2, σ) = (Symbol[:x], :(()), :(()), Symbol[:x])
+naiveunify: Error During Test at /Users/shin/Projects/github/cheaplogic/Prover/test_naiveunify.jl:28
+  Test threw exception
+  Expression: unify([:x], $(Expr(:quote, :(()))), $(Expr(:quote, :(())))) == [:x]
+  BoundsError: attempt to access 0-element Array{Any,1} at index [1]
+  Stacktrace:
+   [1] getindex at ./array.jl:729 [inlined]
+   [2] unify1(::Array{Symbol,1}, ::Expr, ::Expr, ::Array{Symbol,1}) at /Users/shin/Projects/github/cheaplogic/Prover/naiveunify.jl:47
+   [3] unify(::Array{Symbol,1}, ::Expr, ::Expr) at /Users/shin/Projects/github/cheaplogic/Prover/unify.jl:302
+   [4] top-level scope at /Users/shin/Projects/github/cheaplogic/Prover/test_naiveunify.jl:28
+   [5] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/Test/src/Test.jl:1083
+   [6] top-level scope at /Users/shin/Projects/github/cheaplogic/Prover/test_naiveunify.jl:26
+###
+
+   ☕️ unify1(v,t1,t2,σ)の冒頭でt1==t2のとき↑σとした。unify()から呼ぶときはt1==t2のときunify1にこないのだが
+　　　ほかのパスがあるらしい
+      
+2. メモ
+　↑X を書いてみたかった
+
+  macro ↑(v)
+   return :(return $v)
+  end
+
+　としたら
+
+  function a(x)
+    if x == 3; @↑8 end
+    @↑ 19
+  end
+  として
+  julia> a(3)
+  8
+  julia> a(23)
+  19
+
+とは書けた。
+
+
+
+
+
+　  
 20190817土
 1. maxでなく、そのリテラルの前のwhendoit+1にしてみた
 今の例では,partialもabortもうごく

--- a/Prover/dvcreso.jl
+++ b/Prover/dvcreso.jl
@@ -76,7 +76,6 @@ end
 ## for renamed vars explosion
 #fitting vars in literal
 function fitting_vars_term(vars, term)
-@info :fitting_vars_term vars term
   if issym(term) 
     if isvar(term, vars)
       return [term]
@@ -101,7 +100,6 @@ function fitting_vars_lit(vars, lit)
 end
 
 function fitting_vars(vars, lits, core)
-@info :fitting_vars vars, lits
  evars = []
  for lit in lits
    append!(evars, fitting_vars_lit(vars, lit))

--- a/Prover/kpcore.jl
+++ b/Prover/kpcore.jl
@@ -37,6 +37,7 @@ struct STEP
  rule
 end
 
+#==
 mutable struct CORE
  name
  maxcid
@@ -52,6 +53,7 @@ mutable struct CORE
  trycnt
  succnt
 end
+==#
 
 function stringtoclause(cid, cls)
  vars = cls.args[1].args

--- a/Prover/naiveunify.jl
+++ b/Prover/naiveunify.jl
@@ -43,6 +43,7 @@ function direction(vars::Vlist, t1::Any, t2::Any)
 end
 
 function unify1(vars::Vlist, t1::Expr, t2::Expr, σ::Tlist)::Tlist
+  if t1 == t2; return σ end
   if t1.args[1] != t2.args[1]; throw(ICMP(t1,t2,:unify1ee)) end
   while true
     Δ=disagreement(t1, t2)

--- a/Prover/test_naiveunify.jl
+++ b/Prover/test_naiveunify.jl
@@ -1,4 +1,7 @@
 # test for naiveunify.jl
+## this file is called by test_naivelogic.jl
+## not statndalone test
+
 using Test
 
 #include("naiveunify.jl")


### PR DESCRIPTION
  1) in test_kplogic.jl, kpcore.jl has old CORE def. commented out it.
  2) in test_naivelogic.jl, unify1([x], (),(),σ) fail to try args of ().
     in front of unify1, let if t1==t2 return σ.

	modified:   README
	modified:   docs/devlog
	modified:   dvcreso.jl
	modified:   kpcore.jl
	modified:   naiveunify.jl
	modified:   test_naiveunify.jl